### PR TITLE
Add support for non-periodic planar meshes (Fixes #2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
+authors = ["SciDAC Team"]
 name = "MOKA"
 uuid = "4c5738b9-ea62-4abc-b436-bc5c16744d63"
-authors = ["SciDAC Team"]
 version = "0.1.0"
 
 [deps]
@@ -27,8 +27,11 @@ StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
-[weakdeps]
-Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
-
 [extensions]
 MPASEnzymeExt = "Enzyme"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
+
+[weakdeps]
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 MPICH_jll = "7cb0a576-ebde-5e09-9194-50597f1243b4"
 MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -26,8 +27,8 @@ StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
-[extensions]
-MPASEnzymeExt = "Enzyme"
-
 [weakdeps]
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+
+[extensions]
+MPASEnzymeExt = "Enzyme"

--- a/src/forward/init.jl
+++ b/src/forward/init.jl
@@ -47,11 +47,10 @@ function ocn_setup_mesh(Config::GlobalConfig; backend=KA.CPU())
     mesh_fp = ConfigGet(meshConfig, "filename_template")
     # read the inut mesh from the configuartion file 
     # NOTE: This might be a restart file based on config options 
-    
-    h_mesh = ReadHorzMesh(mesh_fp; backend=backend)
-    v_mesh = VerticalMesh(mesh_fp, h_mesh; backend=backend)
-
-    return Mesh(h_mesh, v_mesh)
+    # ---------------------------------------------------
+    # TODO: read `nVertLevels` from the config file
+    # ---------------------------------------------------
+    return Mesh(mesh_fp; nVertLevels=1, backend=backend)
 end 
 
 function ocn_setup_clock(Config::GlobalConfig)

--- a/src/infra/MPASMesh/HorzMesh.jl
+++ b/src/infra/MPASMesh/HorzMesh.jl
@@ -254,7 +254,8 @@ function readEdgeInfo(ds)
 
     # dimension data
     nEdges = ds.dim["nEdges"]
-    nVertLevels = ds.dim["nVertLevels"]
+    # base meshes don't neccessarily have vertical levels
+    nVertLevels = haskey(ds.dim, "nVertLevels") ? ds.dim["nVertLevels"] : 1
 
     # coordinate data 
     xᵉ = ds["xEdge"][:]

--- a/src/infra/MPASMesh/MPASMesh.jl
+++ b/src/infra/MPASMesh/MPASMesh.jl
@@ -19,8 +19,16 @@ const KA = KernelAbstractions
 struct Mesh{HM,VM}
     HorzMesh::HM
     VertMesh::VM
-    # inner constructor should check meshes are 
-    # on the same backend
+
+    function Mesh(HorzMesh::HM, VertMesh::VM) where {HM,VM}
+
+        # set the horizontal boundary masks
+        setBoundaryMask!(HorzMesh.Edges,        VertMesh)
+        #setBoundaryMask!(HorzMesh.DualCells,    VertMesh)
+        #setBoundaryMask!(HorzMesh.PrimaryCells, VertMesh)
+
+        new{HM, VM}(HorzMesh, VertMesh)
+    end
 end
 
 function Adapt.adapt_structure(backend, x::Mesh)

--- a/src/infra/MPASMesh/VertMesh.jl
+++ b/src/infra/MPASMesh/VertMesh.jl
@@ -132,8 +132,8 @@ function VerticalMesh(mesh; nVertLevels=1, backend=KA.CPU())
     restingThickness    = KA.ones(backend, Float64, nCells)
     restingThicknessSum = KA.ones(backend, Float64, nCells) # MIGHT NEED TO CHANGE THIS
 
-    ActiveLevelsEdge = ActiveLevels{Edge}(maxLevelCells, mesh; backend=backend)
-    ActiveLevelsVertex = ActiveLevels{Vertex}(maxLevelCells, mesh; backend=backend)
+    ActiveLevelsEdge = ActiveLevels{Edge}(maxLevelCell, mesh; backend=backend)
+    ActiveLevelsVertex = ActiveLevels{Vertex}(maxLevelCell, mesh; backend=backend)
 
     # All array have been allocated on the requested backend,
     # so no need to call methods from Adapt

--- a/src/ocn/Tendencies/normalVelocity/horizontal_momentum_mixing.jl
+++ b/src/ocn/Tendencies/normalVelocity/horizontal_momentum_mixing.jl
@@ -20,7 +20,7 @@ function horizontal_momentum_mixing_tendency!(Tend::TendencyVars,
 
     @unpack maxLevelEdge = VertMesh 
     @unpack nEdges, dcEdge, dvEdge = Edges
-    @unpack cellsOnEdge, verticesOnEdge = Edges
+    @unpack cellsOnEdge, verticesOnEdge, edgeMask = Edges
 
     # unpack the normal velocity tendency term
     @unpack tendNormalVelocity = Tend 
@@ -40,7 +40,8 @@ function horizontal_momentum_mixing_tendency!(Tend::TendencyVars,
             dcEdge,
             dvEdge,
             viscDel2, # WHERE IS THIS COMING FROM?
-            macLevelEdge.Top,
+            maxLevelEdge.Top,
+            edgeMask,
             ndrange=nEdges)
 
     # sync the backend 
@@ -58,8 +59,8 @@ end
                                                   @Const(dcEdge), 
                                                   @Const(dvEdge), 
                                                   @Const(viscDel2),
-                                                  @Const(maxLevelEdgeTop)) 
-
+                                                  @Const(maxLevelEdgeTop), 
+                                                  @Const(edgeMask))
     # global indices over nEdges
     iEdge = @index(Global, Linear)
     
@@ -75,6 +76,6 @@ end
         @inbounds tendency[k, iEdge] += (
             (div[k, iCell2] - div[k, iCell1]) * dcEdgeInv -
             (relVort[k, iVertex2] - relVort[k, iVertex1]) * dvEdgeInv) *
-            viscDel2 # * edgemask
+            viscDel2 * edgeMask[k, iEdge]
     end
 end

--- a/test/enzyme/test_Enzyme_Operators.jl
+++ b/test/enzyme/test_Enzyme_Operators.jl
@@ -21,12 +21,11 @@ let
 backends = [KA.CPU(), CUDABackend()]
 for backend in backends
     @show backend
-    # Read in the purely horizontal doubly periodic testing mesh
-    HorzMesh = ReadHorzMesh(mesh_fn; backend=backend)
-    # Create a dummy vertical mesh from the horizontal mesh
-    VertMesh = VerticalMesh(HorzMesh; nVertLevels=1, backend=backend)
+
     # Create a the full Mesh strucutre 
-    MPASMesh = Mesh(HorzMesh, VertMesh)
+    MPASMesh = Mesh(mesh_fn; nVertLevels=1, backend=backend)
+    # Unpack the horizontal and vertcial mesh structs
+    @unpack HorzMesh, VertMesh = MPASMesh
 
     setup = TestSetup(MPASMesh, PlanarTest; backend=backend)
 
@@ -63,12 +62,10 @@ for backend in backends
                         Const(backend))
     @allowscalar dnorm_dscalar_rev = d_Scalar[kBegin]
 
-    # Read in the purely horizontal doubly periodic testing mesh
-    HorzMesh = ReadHorzMesh(mesh_fn; backend=backend)
-    # Create a dummy vertical mesh from the horizontal mesh
-    VertMesh = VerticalMesh(HorzMesh; nVertLevels=1, backend=backend)
     # Create a the full Mesh strucutre 
-    MPASMesh = Mesh(HorzMesh, VertMesh)
+    MPASMesh = Mesh(mesh_fn; nVertLevels=1, backend=backend)
+    # Unpack the horizontal and vertcial mesh structs
+    @unpack HorzMesh, VertMesh = MPASMesh
 
     setup = TestSetup(MPASMesh, PlanarTest; backend=backend)
     fill!(d_gradNum, 0.0)
@@ -95,10 +92,8 @@ for backend in backends
     end
 
     @allowscalar dnorm_dscalar_fwd = d_gradNum[kEnd]
-
-
-    HorzMeshFD = ReadHorzMesh(mesh_fn; backend=backend)
-    MPASMeshFD = Mesh(HorzMeshFD, VertMesh)
+    MPASMeshFD = Mesh(mesh_fn; nVertLevels=1, backend=backend)
+    HorzMeshFD = MPASMeshFD.HorzMesh
     ϵ = 1e-8
 
     # For comparison, let's compute the derivative by hand for a given scalar entry:
@@ -160,12 +155,10 @@ for backend in backends
                         Duplicated(deepcopy(MPASMesh), d_MPASMesh),
                         Const(backend))
     @allowscalar dnorm_dvecedge_rev    = d_VecEdge[kBegin]
-    # Read in the purely horizontal doubly periodic testing mesh
-    HorzMesh = ReadHorzMesh(mesh_fn; backend=backend)
-    # Create a dummy vertical mesh from the horizontal mesh
-    VertMesh = VerticalMesh(HorzMesh; nVertLevels=1, backend=backend)
     # Create a the full Mesh strucutre 
-    MPASMesh = Mesh(HorzMesh, VertMesh)
+    MPASMesh = Mesh(mesh_fn; nVertLevels=1, backend=backend)
+    # Unpack the horizontal and vertcial mesh structs
+    @unpack HorzMesh, VertMesh = MPASMesh
 
     setup = TestSetup(MPASMesh, PlanarTest; backend=backend)
     fill!(d_divNum, 0.0)
@@ -191,8 +184,8 @@ for backend in backends
     @test fwd_mode
 
     @allowscalar dnorm_dvecedge_fwd = d_divNum[kEnd]
-    HorzMeshFD = ReadHorzMesh(mesh_fn; backend=backend)
-    MPASMeshFD = Mesh(HorzMeshFD, VertMesh)
+    MPASMeshFD = Mesh(mesh_fn; nVertLevels=1, backend=backend)
+    HorzMeshFD = MPASMeshFD.HorzMesh
     ϵ = 1e-8
     # For comparison, let's compute the derivative by hand for a given VecEdge entry:
     VecEdgeP = 𝐅ₑ(setup, PlanarTest)

--- a/test/ocn/test_Operators.jl
+++ b/test/ocn/test_Operators.jl
@@ -14,12 +14,10 @@ mesh_fn = DownloadMesh(PlanarTest)
 #backend = KA.CPU()
 backend = CUDABackend();
 
-# Read in the purely horizontal doubly periodic testing mesh
-HorzMesh = ReadHorzMesh(mesh_fn; backend=backend)
-# Create a dummy vertical mesh from the horizontal mesh
-VertMesh = VerticalMesh(HorzMesh; nVertLevels=10, backend=backend)
 # Create a the full Mesh strucutre 
-MPASMesh = Mesh(HorzMesh, VertMesh)
+MPASMesh = Mesh(mesh_fn; nVertLevels=10, backend=backend)
+# Unpack the horizontal and vertcial mesh structs
+@unpack HorzMesh, VertMesh = MPASMesh
 
 # get some dimension information
 nEdges = HorzMesh.Edges.nEdges


### PR DESCRIPTION
This PR fixes #2. `maxLevelEdge`/`maxLevelVertex` are now properly initialized based on the `maxLevelCell` value. In order to do this, I've made use of `OffsetArrays` to make `maxLevelCell`/`maxLevelEdge`/`maxLevelVertex` arrays zero indexed and be the dimension length plus one. This way when the a `cellOnEdge`/`cellOnVerex` is missing (i.e. 0), the padded entry for `maxLevelCell` is used, which is always 0 (meaning it's "dry"). 

With these properly initialized `maxLevel*` arrays, the `edgeMask` variable has been added to the `Edges` structure. While, technically a `cellMask` and `vertexMask` can also be initialized, they are so rarely used in actual computation that I've held off from adding them. 